### PR TITLE
[TASK] Fix Test Generation with newer class names

### DIFF
--- a/Classes/CodeGeneration/Testing/ViewHelperTestCaseGenerator.php
+++ b/Classes/CodeGeneration/Testing/ViewHelperTestCaseGenerator.php
@@ -75,7 +75,7 @@ class Tx_Builder_CodeGeneration_Testing_ViewHelperTestCaseGenerator
 	 * @return void
 	 */
 	protected function appendCommonTestMethods() {
-		$nodeClassName = (FALSE === strpos($this->viewHelperClassName, '_') ? 'Tx_Fluid_Core_Parser_SyntaxTree_ViewHelperNode' : '\\TYPO3\\CMS\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode');
+		$nodeClassName = (FALSE !== strpos($this->viewHelperClassName, '_') ? 'Tx_Fluid_Core_Parser_SyntaxTree_ViewHelperNode' : '\\TYPO3\\CMS\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode');
 		$variables = array(
 			'class' => $this->viewHelperClassName,
 			'nodeclass' => $nodeClassName,


### PR DESCRIPTION
This should prevent builder from using newer class names.
Otherwise it would use always newer class Names for 6.x

For running tests on a 4.5 environment, we _need_ underscored naming.
