### PR TITLE
[TASK] Add XML Namespace to templates

### DIFF
--- a/Resources/Private/CodeTemplates/Fluid/FluxContent.phpt
+++ b/Resources/Private/CodeTemplates/Fluid/FluxContent.phpt
@@ -1,5 +1,9 @@
 {namespace flux=Tx_Flux_ViewHelpers}
 <f:layout name="###layout###" />
+<div xmlns="http://www.w3.org/1999/xhtml"
+     xmlns:flux="http://fedext.net/ns/flux/ViewHelpers"
+     xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
+     xmlns:f="http://typo3.org/ns/fluid/ViewHelpers">
 <f:section name="###configurationSectionName###">
 	<flux:flexform id="###id###" label="###label###" icon="###icon###">
 		<!-- Insert fields, sheets, grid, form section objects etc. here, in this flux:flexform tag -->
@@ -14,3 +18,4 @@
 <f:section name="###section###">
 	Hello world!
 </f:section>
+</div>

--- a/Resources/Private/CodeTemplates/Fluid/FluxForm.phpt
+++ b/Resources/Private/CodeTemplates/Fluid/FluxForm.phpt
@@ -1,5 +1,9 @@
 {namespace flux=Tx_Flux_ViewHelpers}
 <f:layout name="###layout###" />
+<div xmlns="http://www.w3.org/1999/xhtml"
+     xmlns:flux="http://fedext.net/ns/flux/ViewHelpers"
+     xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
+     xmlns:f="http://typo3.org/ns/fluid/ViewHelpers">
 <f:section name="###configurationSectionName###">
 	<flux:flexform id="###id###" label="###label###" icon="###icon###">
 		<!-- Insert fields, sheets, grid, form section objects etc. here, in this flux:flexform tag -->
@@ -9,3 +13,4 @@
 <f:section name="###section###">
 	Hello world!
 </f:section>
+</div>


### PR DESCRIPTION
It doesnt hurt to deliver some additional comfort to developers.

FT3 extensions are direct dependencies (depending on the selection).
So instead of having the dev to actually add the namespaces, we simply append
it. Deleting stuff is easier than adding.

Fixes #9 
