### PR TITLE
[BUGFIX] Add vhs dependency

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -38,6 +38,7 @@ $EM_CONF[$_EXTKEY] = array(
 			'cms' => '',
 			'extbase' => '',
 			'fluid' => '',
+			'vhs' => ''
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
Builder has a vhs dependency in the Syntax Analyzer

Fixes #31
