### PR TITLE
[TASK] Enable testing with TYPO3 6.3-dev, remove TYPO3 6.0 and add PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
 env:
   - DB=mysql TYPO3=master INTEGRATION=master
+  - DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master
   - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master
-  - DB=mysql TYPO3=TYPO3_6-0 INTEGRATION=master
 
 matrix:
    fast_finish: true
    include:
-     - php: 5.5
+     - php: 5.6
        env: DB=mysql TYPO3=master INTEGRATION=master
+     - php: 5.6
+       env: DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master
 
 before_script:
   - cd ..


### PR DESCRIPTION
Fails until TYPO3_6-2 is tagged in introduction package
