### PR TITLE
[TASK] Normalize package namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "ft3/builder",
+	"name": "fluidtypo3/builder",
 	"require": {
 		"composer/installers": "*"
 	},


### PR DESCRIPTION
Change Package namespace to fluidtypo3 so that all FluidTYPO3 packages use the same one.
