### PR TITLE
[BUGFIX] Fluid profiling

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -187,7 +187,7 @@ class BackendController extends ActionController {
 						$shortFilename = substr($file, strlen($extensionFolder . '/Resources/Private'));
 						/** @var TemplateAnalyzer $templateAnalyzer */
 						$templateAnalyzer = $this->objectManager->get('FluidTYPO3\Builder\Analysis\Fluid\TemplateAnalyzer');
-						$reportsForSyntaxName[$shortFilename] = $templateAnalyzer->analyze($file);
+						$reportsForSyntaxName[$shortFilename] = $templateAnalyzer->analyzePathAndFilename($file);
 					}
 					$reports[$extensionKey][$syntaxName]['json'] = $this->encodeMetricsToJson($reportsForSyntaxName);
 				}


### PR DESCRIPTION
Profiling is broken since commit 2525cab6.
`analyze` in `TemplateAnalyzer` was changed to accept a template string instead of a filename, but that change was not reflected in `BackendController`.