### PR TITLE
Generate flux:field.input instead of field.inline

### DIFF
--- a/Resources/Private/CodeTemplates/Fluid/Content.phpt
+++ b/Resources/Private/CodeTemplates/Fluid/Content.phpt
@@ -8,7 +8,7 @@
 	<f:section name="###configurationSectionName###">
 		<flux:form id="###formId###" options="{group: 'FCE'}">
 			<!-- Insert fields, sheets, grid, form section objects etc. here, in this flux:flexform tag -->
-			<flux:field.inline name="settings.helloWorld" required="true" />
+			<flux:field.input name="settings.helloWorld" required="true" />
 		</flux:form>
 	</f:section>
 


### PR DESCRIPTION
TYPO3 6.2 displays nothing when using flux:field.inline.
flux:field.input makes the input field work in the backend,
so we use this instead.

Fixes: #94