### PR TITLE
[TASK] Include vhs dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "The builder package from FluidTYPO3",
     "type": "typo3-cms-extension",
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "fluidtypo3/vhs": ">=2.2.0"
     },
     "require-dev": {
         "fluidtypo3/development": "^3.0"


### PR DESCRIPTION
When [vhs was declared as a dependency](https://github.com/FluidTYPO3/builder/pull/32/commits/b2c7d5ba0129f8ce8dadf297e200d48c0d3e10a3) in the `ext_emconf.php` Composer probably wasn't relevant for the TYPO3 world.

Today it would be nice to have the dependency declared also within the `composer.json` so that Composer is able to resolve it.

However I'm not sure about the version constraint. I tried to have it as close to what `ext_emconf.php` dictated.

Greetings
