### PR TITLE
Remove old parameter class

### DIFF
--- a/Resources/Private/Layouts/Backend.html
+++ b/Resources/Private/Layouts/Backend.html
@@ -27,7 +27,7 @@
 
 		<div id="typo3-docbody">
 			<div id="typo3-inner-docbody">
-				<f:flashMessages class="tx-extbase-flash-message" />
+				<f:flashMessages />
 				<f:render section="Content" />
 			</div>
 		</div>


### PR DESCRIPTION
Remove parameter class since it broke the backend layout in typo3 8 (Issue #114)