### PR TITLE
Make builder compatible with vhs 6.0 and fix syntax validator

### DIFF
--- a/Classes/Service/SyntaxService.php
+++ b/Classes/Service/SyntaxService.php
@@ -27,7 +27,7 @@ namespace FluidTYPO3\Builder\Service;
 use FluidTYPO3\Builder\Parser\ExposedTemplateParser;
 use FluidTYPO3\Builder\Result\FluidParserResult;
 use FluidTYPO3\Builder\Utility\GlobUtility;
-use FluidTYPO3\Flux\Utility\VersionUtility;
+use FluidTYPO3\Builder\Utility\VersionUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;

--- a/Classes/Utility/VersionUtility.php
+++ b/Classes/Utility/VersionUtility.php
@@ -1,0 +1,39 @@
+<?php
+namespace FluidTYPO3\Builder\Utility;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * VersionUtility
+ */
+class VersionUtility
+{
+
+    /**
+     * @param string $extensionKey
+     * @param integer $majorVersion
+     * @param integer $minorVersion
+     * @param integer $bugfixVersion
+     * @return boolean
+     */
+    public static function assertExtensionVersionIsAtLeastVersion(
+        $extensionKey,
+        $majorVersion,
+        $minorVersion = 0,
+        $bugfixVersion = 0
+    ) {
+        if (false === ExtensionManagementUtility::isLoaded($extensionKey)) {
+            return false;
+        }
+        $extensionVersion = ExtensionManagementUtility::getExtensionVersion($extensionKey);
+        list ($major, $minor, $bugfix) = explode('.', $extensionVersion);
+        return ($majorVersion <= $major && $minorVersion <= $minor && $bugfixVersion <= $bugfix);
+    }
+}

--- a/Resources/Private/Layouts/Backend.html
+++ b/Resources/Private/Layouts/Backend.html
@@ -6,10 +6,10 @@
 				<div class="left">
 					<f:render section="FunctionsLeft" />
 					<f:form style="display: inline-block">
-						<v:form.select additionalAttributes='{onchange: "jumpToUrl(this.options[this.selectedIndex].value,this);"}' selectAllByDefault="{f:uri.action(action: 'index')}">
-							<v:form.select.option value="{f:uri.action(action: 'index')}" selected="{f:if(condition: '{view}==\'Index\'', then: '1', else: '0')}">Syntax</v:form.select.option>
-							<v:form.select.option value="{f:uri.action(action: 'buildForm')}" selected="{f:if(condition: '{view}==\'BuildForm\'', then: '1', else: '0')}">Build provider</v:form.select.option>
-						</v:form.select>
+						<f:form.select additionalAttributes='{onchange: "jumpToUrl(this.options[this.selectedIndex].value,this);"}' selectAllByDefault="{f:uri.action(action: 'index')}">
+							<f:form.select.option value="{f:uri.action(action: 'index')}" selected="{f:if(condition: '{view}==\'Index\'', then: '1', else: '0')}">Syntax</f:form.select.option>
+							<f:form.select.option value="{f:uri.action(action: 'buildForm')}" selected="{f:if(condition: '{view}==\'BuildForm\'', then: '1', else: '0')}">Build provider</f:form.select.option>
+						</f:form.select>
 					 </f:form>
 				</div>
 				<div class="right"></div>
@@ -27,7 +27,13 @@
 
 		<div id="typo3-docbody">
 			<div id="typo3-inner-docbody">
-				<f:flashMessages />
+				<f:flashMessages as="flashMessages">
+					<ul class="tx-extbase-flash-message">
+						<f:for each="{flashMessages}" as="flashMessage">
+							<li>{flashMessage.message}</li>
+						</f:for>
+					</ul>
+				</f:flashMessages>
 				<f:render section="Content" />
 			</div>
 		</div>

--- a/Resources/Private/Templates/Backend/Syntax.html
+++ b/Resources/Private/Templates/Backend/Syntax.html
@@ -25,13 +25,13 @@
 		<f:for each="{extensions}" as="extensionName">
 			<f:form.hidden name="extensions[]" value="{extensionName}" />
 		</f:for>
-		<v:form.select name="filteredFiles" size="{files -> f:count()}" multiple="multiple">
+		<f:form.select name="filteredFiles" size="{files -> f:count()}" multiple="multiple">
 			<f:for each="{files}" as="filterFile">
-				<v:form.select.option value="{filterFile}" selected="{v:condition.iterator.contains(needle: filterFile, haystack: filteredFiles, then: 'selected')}" class="form-control">
+				<f:form.select.option value="{filterFile}" selected="{v:condition.iterator.contains(needle: filterFile, haystack: filteredFiles, then: 'selected')}" class="form-control">
 					{filterFile -> v:format.substring(start: basePathLength)}
-				</v:form.select.option>
+				</f:form.select.option>
 			</f:for>
-		</v:form.select><br />
+		</f:form.select><br />
 		<button name="go" class="btn btn-primary">
 			<span class="t3-icon fa fa-refresh"> </span>
 			{f:translate(key: 'rerun')}

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,7 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' => array (
       'php' => '7.0.0-7.2.99',
       'typo3' => '8.7.0-9.5.99',
-      'vhs' => '2.2.0-5.99.99',
+      'vhs' => '2.2.0-6.99.99',
     ),
     'conflicts' => array (
     ),


### PR DESCRIPTION
Make builder compatible with vhs 6.0 and fix syntax validator because of flux VersionUtility legacy.