### PR TITLE
Change file extension of the typoscript generated for the provider extension

### DIFF
--- a/Classes/CodeGeneration/Extension/ExtensionGenerator.php
+++ b/Classes/CodeGeneration/Extension/ExtensionGenerator.php
@@ -187,11 +187,11 @@ class ExtensionGenerator extends AbstractCodeGenerator implements CodeGeneratorI
             'signature' => ExtensionManagementUtility::getCN($extensionKey)
         ];
         $folder = $this->targetFolder . '/Configuration/TypoScript';
-        $files[$folder . '/constants.txt'] = $this->getPreparedCodeTemplate(
+        $files[$folder . '/constants.typoscript'] = $this->getPreparedCodeTemplate(
             self::TEMPLATE_TYPOSCRIPTCONSTANTS,
             $templateVariables
         )->render();
-        $files[$folder . '/setup.txt'] = $this->getPreparedCodeTemplate(
+        $files[$folder . '/setup.typoscript'] = $this->getPreparedCodeTemplate(
             self::TEMPLATE_TYPOSCRIPTSETUP,
             $templateVariables
         )->render();


### PR DESCRIPTION
While the .txt extension is still valid, the core uses the .typoscript extension. The pull request reflects this for the generation process of a provider extension.